### PR TITLE
Fixed view on mobile phone

### DIFF
--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="x-ua-compatible" content="IE=Edge"> 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{{#title}}{{.}} | {{/title}}{{site.name}}</title>
 	<link href="/css/all.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Never ever ever disable zooming, especially on web with broken/nonexisting responsive elements. It leads to bad usability.